### PR TITLE
Unset PGPASSWORD before starting PostgreSQL to allow the use of .pgpass file for replication password.

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -470,8 +470,16 @@ pgsql_real_start() {
     # Tack pass-through options onto pg_ctl options
     pgctl_options="$pgctl_options -o '$postgres_options'"
 
+    # Unset PGPASSWORD, because it will cause postgresql to ignore .pgpass file for replication purposes... maybe this is not the best way, but I can't think of anything simpler for now.
+    unset PGPASSWORD
+
     # Invoke pg_ctl
     runasowner "$OCF_RESKEY_pgctl $pgctl_options start"
+
+    # Set it again here, as we are calling monitor.
+    if [ -n $OCF_RESKEY_monitor_password ]; then
+        PGPASSWORD=$OCF_RESKEY_monitor_password; export PGPASSWORD
+    fi
 
     if [ $? -eq 0 ]; then
         # Probably started.....


### PR DESCRIPTION
Unset PGPASSWORD before starting PostgreSQL to allow the use of .pgpass file for replication password.

If we leave PGPASSWORD set, PostgreSQL process will ignore .pgpass file, and PGPASSWORD is set to monitor_password by the script (which can be different from replication password).

There maybe be better ways to fix this, for example, use another variable to hold the monitor_password, and set PGPASSWORD _only_ when we will use it, and unset it afterwards (for example).  Consider this commit a quick hack to fix the fact that PostgreSQL process was totally ignoring .pgpass file for replication, and was trying to use monitor_password for replication.
